### PR TITLE
Fix undefined offset notice first time the settings page is visited …

### DIFF
--- a/features/detection/detection.php
+++ b/features/detection/detection.php
@@ -70,6 +70,13 @@ class Tabify_Edit_Screen_Feature_Detection {
 			);
 			$post = get_posts( $args );
 
+			if ( empty( $post ) ) {
+				$this->allowed_request_errors--;
+
+				set_transient( 'tabify_detection_stop_detecting', true, HOUR_IN_SECONDS );
+				return;
+			}
+
 			$url = get_edit_post_link( $post[0], 'raw' );
 			$url = add_query_arg( 'tes_metaboxes', 'true', $url );
 


### PR DESCRIPTION
…on a virgin site.

Fixes error notice:
`PHP Notice:  Undefined offset: 0 in /path/to/wp-content/plugins/tabify-edit-screen/features/detection/detection.php on line 76`

This error occurs when the settings page is visited before any posts have been added.
As this is likely a temporary situation, the time out for the transient is set to an hour to allow for users starting to add posts.
